### PR TITLE
fix: export VectorImageAsset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/pdi-common-impl",
-  "version": "0.2.0-feature.0",
+  "version": "0.2.0-feature.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/pdi-common-impl",
-      "version": "0.2.0-feature.0",
+      "version": "0.2.0-feature.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/trigger": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/pdi-common-impl",
-  "version": "0.2.0-feature.0",
+  "version": "0.2.0-feature.1",
   "description": "Common implementation of PDI",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,6 @@ export * from "./ResourceFactory";
 export * from "./ScriptAsset";
 export * from "./Surface";
 export * from "./TextAsset";
+export * from "./VectorImageAsset";
 export * from "./VideoAsset";
 export * from "./VideoPlayer";


### PR DESCRIPTION
## このPullRequestが解決する内容
#19 にて `VectorImageAsset` を export し忘れたため export するように修正します。
自明のためセルフマージします。