### PR TITLE
Fix jest.config, eslint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
 	},
 	globals: {
 		"ts-jest": {
-			tsConfig: "tsconfig.jest.json"
+			tsconfig: "tsconfig.jest.json"
 		}
 	},
 	testMatch: [

--- a/src/Asset.ts
+++ b/src/Asset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Trigger } from "@akashic/trigger";
 
 /**

--- a/src/AudioAsset.ts
+++ b/src/AudioAsset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Asset } from "./Asset";
 
 /**
@@ -36,14 +36,14 @@ export abstract class AudioAsset extends Asset implements pdi.AudioAsset {
 	}
 
 	play(): pdi.AudioPlayer {
-		let player = this._system.createPlayer();
+		const player = this._system.createPlayer();
 		player.play(this);
 		this._lastPlayedPlayer = player;
 		return player;
 	}
 
 	stop(): void {
-		let players = this._system.findPlayers(this);
+		const players = this._system.findPlayers(this);
 		for (let i = 0; i < players.length; ++i) players[i].stop();
 	}
 

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Trigger } from "@akashic/trigger";
 
 /**
@@ -92,7 +92,7 @@ export class AudioPlayer implements pdi.AudioPlayer {
 	 * 再生中でない場合、何もしない(`onStop` もfireされない)。
 	 */
 	stop(): void {
-		let audio = this.currentAudio;
+		const audio = this.currentAudio;
 		if (!audio) return;
 		this.currentAudio = undefined;
 		this.onStop.fire({

--- a/src/ExceptionFactory.ts
+++ b/src/ExceptionFactory.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 
 /**
  * 例外生成ファクトリ。
@@ -6,7 +6,7 @@ import * as pdi from "@akashic/pdi-types";
  */
 export module ExceptionFactory {
 	export function createAssertionError(message: string, cause?: any): pdi.AssertionError {
-		let e: pdi.AssertionError = <pdi.AssertionError> new Error(message);
+		const e: pdi.AssertionError = <pdi.AssertionError> new Error(message);
 		e.name = "AssertionError";
 		e.cause = cause;
 		return e;
@@ -29,7 +29,7 @@ export module ExceptionFactory {
 			}
 		}
 		message += ".";
-		let e: pdi.TypeMismatchError = <pdi.TypeMismatchError> new Error(message);
+		const e: pdi.TypeMismatchError = <pdi.TypeMismatchError> new Error(message);
 		e.name = "TypeMismatchError";
 		e.cause = cause;
 		e.expected = expected;
@@ -43,7 +43,7 @@ export module ExceptionFactory {
 		_type: unknown = null, // 歴史的経緯により残っている値。利用していない。
 		cause?: any
 	): pdi.AssetLoadError {
-		let e: pdi.AssetLoadError = <pdi.AssetLoadError> new Error(message);
+		const e: pdi.AssetLoadError = <pdi.AssetLoadError> new Error(message);
 		e.name = "AssetLoadError";
 		e.cause = cause;
 		e.retriable = retriable;

--- a/src/Glyph.ts
+++ b/src/Glyph.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 
 /**
  * グリフ。

--- a/src/GlyphFactory.ts
+++ b/src/GlyphFactory.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 
 /**
  * グリフファクトリ。

--- a/src/ImageAsset.ts
+++ b/src/ImageAsset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Asset } from "./Asset";
 
 /**

--- a/src/PdiCommonUtil.ts
+++ b/src/PdiCommonUtil.ts
@@ -8,7 +8,7 @@ export module PdiCommonUtil {
 	 * @param ext 追加する拡張子
 	 */
 	export function addExtname(path: string, ext: string): string {
-		let index = path.indexOf("?");
+		const index = path.indexOf("?");
 		if (index === -1) {
 			return path + "." + ext;
 		}

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 
 /**
  * ゲームの描画を行うクラス。

--- a/src/ResourceFactory.ts
+++ b/src/ResourceFactory.ts
@@ -1,13 +1,13 @@
-import * as pdi from "@akashic/pdi-types";
-import { AudioAsset } from "./AudioAsset";
-import { AudioPlayer } from "./AudioPlayer";
-import { GlyphFactory } from "./GlyphFactory";
-import { ImageAsset } from "./ImageAsset";
-import { ScriptAsset } from "./ScriptAsset";
-import { Surface } from "./Surface";
-import { TextAsset } from "./TextAsset";
-import { VectorImageAsset } from "./VectorImageAsset";
-import { VideoAsset } from "./VideoAsset";
+import type * as pdi from "@akashic/pdi-types";
+import type { AudioAsset } from "./AudioAsset";
+import type { AudioPlayer } from "./AudioPlayer";
+import type { GlyphFactory } from "./GlyphFactory";
+import type { ImageAsset } from "./ImageAsset";
+import type { ScriptAsset } from "./ScriptAsset";
+import type { Surface } from "./Surface";
+import type { TextAsset } from "./TextAsset";
+import type { VectorImageAsset } from "./VectorImageAsset";
+import type { VideoAsset } from "./VideoAsset";
 
 /**
  * リソースの生成を行うクラス。

--- a/src/ScriptAsset.ts
+++ b/src/ScriptAsset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Asset } from "./Asset";
 
 /**

--- a/src/Surface.ts
+++ b/src/Surface.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { ExceptionFactory } from "./ExceptionFactory";
 
 /**

--- a/src/TextAsset.ts
+++ b/src/TextAsset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Asset } from "./Asset";
 
 /**

--- a/src/VectorImageAsset.ts
+++ b/src/VectorImageAsset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Asset } from "./Asset";
 
 /**

--- a/src/VideoAsset.ts
+++ b/src/VideoAsset.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Asset } from "./Asset";
 
 /**

--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import { Trigger } from "@akashic/trigger";
 
 /**
@@ -83,7 +83,7 @@ export class VideoPlayer implements pdi.VideoPlayer {
 	 * 停止後、 `this.onStop` がfireされる。
 	 */
 	stop(): void {
-		let videoAsset = this.currentVideo;
+		const videoAsset = this.currentVideo;
 		this.onStop.fire({
 			player: this,
 			video: videoAsset

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -1,4 +1,4 @@
-import * as pdi from "@akashic/pdi-types";
+import type * as pdi from "@akashic/pdi-types";
 import * as pci from "../../";
 
 export class AudioSystem implements pdi.AudioSystem {


### PR DESCRIPTION
## 概要

- renovate で ts-jest  更新に伴い config ファイルの非推奨となった `tsConfig` -> `tsconfig`へ変更
- eslint --fix での自動修正
　- import type の適応
　- let -> const へ

renovate の #37 へマージします 