### PR TITLE
update release.yml for trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,11 @@ on:
       - main
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 24
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -17,21 +18,17 @@ jobs:
     name: Publish and Release
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          persist-credentials: false
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - name: Prepare
         run: |
           npm ci
-          npm run build
           npm test
       - name: Publish and Release
         uses: akashic-games/action-release@e4e3c8901b8ed92356c5eb9cf6cfc573a9c4ce9b # v2.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### やったこと
release.yml で Trusted Publish に対応するために以下の変更を加えた。
- nodeのバージョンをv24に更新(npm 11.5.1以降でないとTrusted Publishに対応していないため)
- permissions: id-token: write を追加
- publish時に NPM TOKEN の指定を削除